### PR TITLE
ld64: omit duplicate rpath entries

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,9 +22,10 @@ source:
       - patches/0003-macos-system-dispatch.patch    # [osx]
       # for #76
       - patches/0004-point-target-otool-to-llvm-otool-in-same-folder.patch
+      - patches/0005-omit-duplicate-rpaths.patch    # [osx]
 
 build:
-  number: 4
+  number: 5
   skip: True  # [win]
   ignore_run_exports:
     - zlib

--- a/recipe/patches/0005-omit-duplicate-rpaths.patch
+++ b/recipe/patches/0005-omit-duplicate-rpaths.patch
@@ -1,0 +1,42 @@
+From 8781d67e6288fa315362c5107a991d607fedbaee Mon Sep 17 00:00:00 2001
+From: Min RK <benjaminrk@gmail.com>
+Date: Fri, 4 Apr 2025 16:42:56 +0200
+Subject: [PATCH] omit duplicate rpaths
+
+omit and warn, matching ld-prime
+---
+ cctools/ld64/src/ld/HeaderAndLoadCommands.hpp | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/cctools/ld64/src/ld/HeaderAndLoadCommands.hpp b/cctools/ld64/src/ld/HeaderAndLoadCommands.hpp
+index ab305e1..e5f0b06 100644
+--- a/cctools/ld64/src/ld/HeaderAndLoadCommands.hpp
++++ b/cctools/ld64/src/ld/HeaderAndLoadCommands.hpp
+@@ -31,6 +31,8 @@
+ #include <mach-o/loader.h>
+ #include <string_view>
+ 
++#include <stdio.h>
++#include <set>
+ #include <vector>
+ 
+ #include "MachOFileAbstraction.hpp"
+@@ -1764,8 +1766,15 @@ void HeaderAndLoadCommandsAtom<A>::copyRawContent(uint8_t buffer[]) const
+ 
+ 	if ( _hasRPathLoadCommands ) {
+ 		const std::vector<const char*>& rpaths = _options.rpaths();
++		std::set<std::string> seen_rpaths;
+ 		for (std::vector<const char*>::const_iterator it = rpaths.begin(); it != rpaths.end(); ++it) {
++			const std::string rpath_str = *it;
++			if (seen_rpaths.count(rpath_str)) {
++				fprintf(stderr, "ld: warning: duplicate -rpath '%s' ignored\n", rpath_str.c_str());
++			} else {
+ 			p = this->copyRPathLoadCommand(p, *it);
++			seen_rpaths.insert(rpath_str);
++			}
+ 		}
+ 	}
+ 	
+-- 
+2.47.0
+


### PR DESCRIPTION
matches ld-prime behavior, required to avoid creating broken binaries on macOS 15.4

displays the same warning as ld-prime when ignoring duplicates:

```
ld: warning: duplicate -rpath '@loader_path' ignored
```

removing these in the build tool (https://github.com/conda/conda-build/issues/5671) only solves the problem for conda packages, not runtime compilation/linking. This makes the linker output consistent with the current Apple linker.

should prevent further issues like https://github.com/conda-forge/gfortran_impl_osx-64-feedstock/pull/86 and https://github.com/conda-forge/numpy-feedstock/issues/347 and https://github.com/prefix-dev/pixi/issues/3479