### PR TITLE
update duplicate rpath patch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
       - patches/0005-omit-duplicate-rpaths.patch    # [osx]
 
 build:
-  number: 5
+  number: 6
   skip: True  # [win]
   ignore_run_exports:
     - zlib

--- a/recipe/patches/0005-omit-duplicate-rpaths.patch
+++ b/recipe/patches/0005-omit-duplicate-rpaths.patch
@@ -1,42 +1,49 @@
-From 8781d67e6288fa315362c5107a991d607fedbaee Mon Sep 17 00:00:00 2001
+From 45bb53476f6d97ba4bc670b9a5339df0e8e7a3ea Mon Sep 17 00:00:00 2001
 From: Min RK <benjaminrk@gmail.com>
 Date: Fri, 4 Apr 2025 16:42:56 +0200
 Subject: [PATCH] omit duplicate rpaths
 
 omit and warn, matching ld-prime
 ---
- cctools/ld64/src/ld/HeaderAndLoadCommands.hpp | 9 +++++++++
- 1 file changed, 9 insertions(+)
+ cctools/ld64/src/ld/Options.cpp | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
 
-diff --git a/cctools/ld64/src/ld/HeaderAndLoadCommands.hpp b/cctools/ld64/src/ld/HeaderAndLoadCommands.hpp
-index ab305e1..e5f0b06 100644
---- a/cctools/ld64/src/ld/HeaderAndLoadCommands.hpp
-+++ b/cctools/ld64/src/ld/HeaderAndLoadCommands.hpp
-@@ -31,6 +31,8 @@
- #include <mach-o/loader.h>
- #include <string_view>
+diff --git a/cctools/ld64/src/ld/Options.cpp b/cctools/ld64/src/ld/Options.cpp
+index aafff2d..87433f0 100644
+--- a/cctools/ld64/src/ld/Options.cpp
++++ b/cctools/ld64/src/ld/Options.cpp
+@@ -46,6 +46,7 @@
+ #include <mach-o/dyld_priv.h>
  
-+#include <stdio.h>
+ #include <algorithm>
 +#include <set>
  #include <vector>
+ #include <map>
+ #include <sstream>
+@@ -2585,6 +2586,9 @@ void Options::parse(int argc, const char* argv[])
+ 	// reduce re-allocations
+ 	fInputFiles.reserve(32);
  
- #include "MachOFileAbstraction.hpp"
-@@ -1764,8 +1766,15 @@ void HeaderAndLoadCommandsAtom<A>::copyRawContent(uint8_t buffer[]) const
- 
- 	if ( _hasRPathLoadCommands ) {
- 		const std::vector<const char*>& rpaths = _options.rpaths();
-+		std::set<std::string> seen_rpaths;
- 		for (std::vector<const char*>::const_iterator it = rpaths.begin(); it != rpaths.end(); ++it) {
-+			const std::string rpath_str = *it;
-+			if (seen_rpaths.count(rpath_str)) {
-+				fprintf(stderr, "ld: warning: duplicate -rpath '%s' ignored\n", rpath_str.c_str());
-+			} else {
- 			p = this->copyRPathLoadCommand(p, *it);
-+			seen_rpaths.insert(rpath_str);
-+			}
- 		}
- 	}
- 	
++	// ignore duplicate rpaths
++	std::set<std::string> seen_rpaths;
++
+ 	// pass two parse all other options
+ 	for(int i=1; i < argc; ++i) {
+ 		const char* arg = argv[i];
+@@ -3697,7 +3701,13 @@ void Options::parse(int argc, const char* argv[])
+ 			}
+ 			else if ( strcmp(arg, "-rpath") == 0 ) {
+ 				const char* path = checkForNullArgument(arg, argv[++i]);
++				const std::string rpath_str = path;
++				if (seen_rpaths.count(rpath_str)) {
++					fprintf(stderr, "ld: warning: duplicate -rpath '%s' ignored\n", rpath_str.c_str());
++				} else {
+ 				fRPaths.push_back(path);
++				seen_rpaths.insert(rpath_str);
++				}
+ 			}
+ 			else if ( strcmp(arg, "-read_only_stubs") == 0 ) {
+ 				fReadOnlyx86Stubs = true;
 -- 
 2.47.0
 


### PR DESCRIPTION
skip duplicate rpaths earlier (in cli parsing), otherwise command count might be wrong.

fixes patch in #84 also reflected in https://github.com/tpoechtrager/cctools-port/pull/166

I don't know how to add a test to this feedstock, but I've run this build locally (with `osx_arm64_cross_macos_machinearm64-apple-darwin20.0.0cross_platformosx-arm64llvm_version18`) and it seems to be working as intended.
