### PR TITLE
Handle empty installPath in patch

### DIFF
--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -63,6 +63,25 @@ if [[ "${sha:-}" == "" ]]; then
   sha=$(git rev-parse HEAD)
 fi
 
+if [[ "${OSX_SDK_DIR:-}" == "" ]]; then
+  if [[ "${CI:-}" == "" ]]; then
+    echo "Please set OSX_SDK_DIR to a directory where SDKs can be downloaded to. Aborting"
+    exit 1
+  else
+    export OSX_SDK_DIR=/opt/conda-sdks
+    /usr/bin/sudo mkdir -p "${OSX_SDK_DIR}"
+    /usr/bin/sudo chown "${USER}" "${OSX_SDK_DIR}"
+  fi
+else
+  if tmpf=$(mktemp -p "$OSX_SDK_DIR" tmp.XXXXXXXX 2>/dev/null); then
+      rm -f "$tmpf"
+      echo "OSX_SDK_DIR is writeable without sudo, continuing"
+  else
+      echo "User-provided OSX_SDK_DIR is not writeable for current user! Aborting"
+      exit 1
+  fi
+fi
+
 echo -e "\n\nRunning the build setup script."
 source run_conda_forge_build_setup
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,24 @@ Package license: APSL-2.0
 
 Summary: Assembler, archiver, ranlib, libtool, otool et al for Darwin Mach-O files. Darwin Mach-O linker.
 
+About cctools_impl_osx-64
+-------------------------
+
+Home: https://github.com/tpoechtrager/cctools-port
+
+Package license: APSL-2.0
+
+Summary: Assembler, archiver, ranlib, libtool, otool et al for Darwin Mach-O files
+
+About cctools_impl_osx-arm64
+----------------------------
+
+Home: https://github.com/tpoechtrager/cctools-port
+
+Package license: APSL-2.0
+
+Summary: Assembler, archiver, ranlib, libtool, otool et al for Darwin Mach-O files
+
 About cctools_osx-64
 --------------------
 
@@ -20,7 +38,7 @@ Home: https://github.com/tpoechtrager/cctools-port
 
 Package license: APSL-2.0
 
-Summary: Assembler, archiver, ranlib, libtool, otool et al for Darwin Mach-O files
+Summary: Activation scripts for assembler, archiver, ranlib, libtool, otool et al for Darwin Mach-O files
 
 About cctools_osx-arm64
 -----------------------
@@ -29,7 +47,7 @@ Home: https://github.com/tpoechtrager/cctools-port
 
 Package license: APSL-2.0
 
-Summary: Assembler, archiver, ranlib, libtool, otool et al for Darwin Mach-O files
+Summary: Activation scripts for assembler, archiver, ranlib, libtool, otool et al for Darwin Mach-O files
 
 About ld64_osx-64
 -----------------
@@ -308,6 +326,8 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-cctools-green.svg)](https://anaconda.org/conda-forge/cctools) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/cctools.svg)](https://anaconda.org/conda-forge/cctools) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/cctools.svg)](https://anaconda.org/conda-forge/cctools) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/cctools.svg)](https://anaconda.org/conda-forge/cctools) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-cctools__impl__osx--64-green.svg)](https://anaconda.org/conda-forge/cctools_impl_osx-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/cctools_impl_osx-64.svg)](https://anaconda.org/conda-forge/cctools_impl_osx-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/cctools_impl_osx-64.svg)](https://anaconda.org/conda-forge/cctools_impl_osx-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/cctools_impl_osx-64.svg)](https://anaconda.org/conda-forge/cctools_impl_osx-64) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-cctools__impl__osx--arm64-green.svg)](https://anaconda.org/conda-forge/cctools_impl_osx-arm64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/cctools_impl_osx-arm64.svg)](https://anaconda.org/conda-forge/cctools_impl_osx-arm64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/cctools_impl_osx-arm64.svg)](https://anaconda.org/conda-forge/cctools_impl_osx-arm64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/cctools_impl_osx-arm64.svg)](https://anaconda.org/conda-forge/cctools_impl_osx-arm64) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-cctools__osx--64-green.svg)](https://anaconda.org/conda-forge/cctools_osx-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/cctools_osx-64.svg)](https://anaconda.org/conda-forge/cctools_osx-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/cctools_osx-64.svg)](https://anaconda.org/conda-forge/cctools_osx-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/cctools_osx-64.svg)](https://anaconda.org/conda-forge/cctools_osx-64) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-cctools__osx--arm64-green.svg)](https://anaconda.org/conda-forge/cctools_osx-arm64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/cctools_osx-arm64.svg)](https://anaconda.org/conda-forge/cctools_osx-arm64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/cctools_osx-arm64.svg)](https://anaconda.org/conda-forge/cctools_osx-arm64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/cctools_osx-arm64.svg)](https://anaconda.org/conda-forge/cctools_osx-arm64) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-ld64-green.svg)](https://anaconda.org/conda-forge/ld64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ld64.svg)](https://anaconda.org/conda-forge/ld64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ld64.svg)](https://anaconda.org/conda-forge/ld64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ld64.svg)](https://anaconda.org/conda-forge/ld64) |
@@ -324,16 +344,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `cctools, cctools_osx-64, cctools_osx-arm64, ld64, ld64_osx-64, ld64_osx-arm64` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `cctools, cctools_impl_osx-64, cctools_impl_osx-arm64, cctools_osx-64, cctools_osx-arm64, ld64, ld64_osx-64, ld64_osx-arm64` can be installed with `conda`:
 
 ```
-conda install cctools cctools_osx-64 cctools_osx-arm64 ld64 ld64_osx-64 ld64_osx-arm64
+conda install cctools cctools_impl_osx-64 cctools_impl_osx-arm64 cctools_osx-64 cctools_osx-arm64 ld64 ld64_osx-64 ld64_osx-arm64
 ```
 
 or with `mamba`:
 
 ```
-mamba install cctools cctools_osx-64 cctools_osx-arm64 ld64 ld64_osx-64 ld64_osx-arm64
+mamba install cctools cctools_impl_osx-64 cctools_impl_osx-arm64 cctools_osx-64 cctools_osx-arm64 ld64 ld64_osx-64 ld64_osx-arm64
 ```
 
 It is possible to list all of the versions of `cctools` available on your platform with `conda`:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
       - patches/0006-Find-sigtool-codesign-first.patch
 
 build:
-  number: 3
+  number: 4
   skip: True  # [win]
   ignore_run_exports:
     - zlib

--- a/recipe/patches/0004-avoid-stripping-out-C-stdlib-too-zealously.patch
+++ b/recipe/patches/0004-avoid-stripping-out-C-stdlib-too-zealously.patch
@@ -1,7 +1,7 @@
-From 1f72872e86160c6d97ec69b4883dbd61f4e76fb3 Mon Sep 17 00:00:00 2001
+From 6e124ce2a66df50109869ce7d0dcf7b6fa39254c Mon Sep 17 00:00:00 2001
 From: Lucas Colley <lucas.colley8@gmail.com>
 Date: Thu, 25 Sep 2025 21:24:29 +0100
-Subject: [PATCH 4/5] avoid stripping out C stdlib too zealously
+Subject: [PATCH 4/6] avoid stripping out C stdlib too zealously
 
 this avoids failures on macOS 26 like `must link with at least
 libSystem.dylib`
@@ -10,7 +10,7 @@ libSystem.dylib`
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/cctools/ld64/src/ld/passes/dylibs.cpp b/cctools/ld64/src/ld/passes/dylibs.cpp
-index 8f8ee46..d129024 100644
+index 8f8ee46..8152d31 100644
 --- a/cctools/ld64/src/ld/passes/dylibs.cpp
 +++ b/cctools/ld64/src/ld/passes/dylibs.cpp
 @@ -306,7 +306,7 @@ void doPass(const Options& opts, ld::Internal& state)
@@ -18,7 +18,7 @@ index 8f8ee46..d129024 100644
  			aDylib->setWillBeRemoved(true);
  		// set "willRemoved" bit on any unused explicit when -dead_strip_dylibs is used
 -		if ( opts.deadStripDylibs() && !aDylib->providedExportAtom() && !aDylib->neededDylib() )
-+		if ( opts.deadStripDylibs() && !aDylib->providedExportAtom() && !aDylib->neededDylib() && strncmp(aDylib->installPath(), "/usr/lib/libSystem.", 19) != 0 )
++		if ( opts.deadStripDylibs() && !aDylib->providedExportAtom() && !aDylib->neededDylib() && ( aDylib->installPath() == nullptr || strncmp(aDylib->installPath(), "/usr/lib/libSystem.", 19) != 0 ) )
  			aDylib->setWillBeRemoved(true);
  		// <rdar://problem/48642080> Warn when dylib links itself
  		if ( (opts.outputKind() == Options::kDynamicLibrary) && !aDylib->willRemoved() ) {


### PR DESCRIPTION
I had to pin `cctools` & `ld64` in https://github.com/conda-forge/mysql-feedstock/pull/115 as otherwise, `ld64` would segfault with the following traceback:

```
% lldb "/Users/…/arm64-apple-darwin20.0.0-ld"
(lldb) target create "/Users/…/arm64-apple-darwin20.0.0-ld"
Current executable set to '/Users/…/arm64-apple-darwin20.0.0-ld' (arm64).
(lldb) run -demangle -lto_library …
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x000000019d488a80 libsystem_platform.dylib`_platform_strncmp$VARIANT$Base + 176
libsystem_platform.dylib`_platform_strncmp$VARIANT$Base:
->  0x19d488a80 <+176>: ldr    q0, [x0], #0x10
    0x19d488a84 <+180>: ldr    q1, [x1], #0x10
    0x19d488a88 <+184>: cmeq.16b v1, v0, v1
    0x19d488a8c <+188>: and.16b v0, v0, v1
Target 0: (arm64-apple-darwin20.0.0-ld) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
  * frame #0: 0x000000019d488a80 libsystem_platform.dylib`_platform_strncmp$VARIANT$Base + 176
    frame #1: 0x00000001001c0538 arm64-apple-darwin20.0.0-ld`ld::passes::dylibs::doPass(Options const&, ld::Internal&) + 412
    frame #2: 0x0000000100013c04 arm64-apple-darwin20.0.0-ld`main + 732
    frame #3: 0x000000019d0b5d54 dyld`start + 7184
(lldb)
````

This fix makes the `mysql` build pass again with the latest `ld64` and `cctools` versions.